### PR TITLE
feat: add warmup requests

### DIFF
--- a/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
@@ -5,6 +5,8 @@ import it.pagopa.ecommerce.users.warmup.annotations.WarmupFunction
 import it.pagopa.ecommerce.users.warmup.utils.WarmupUtils
 import it.pagopa.generated.ecommerce.users.api.UserApi
 import it.pagopa.generated.ecommerce.users.model.UserLastPaymentMethodData
+import java.time.Duration
+import java.util.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -12,8 +14,6 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
-import java.time.Duration
-import java.util.*
 
 @RestController("LastUsageControllerV1")
 class LastUsageController(

--- a/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
@@ -5,8 +5,6 @@ import it.pagopa.ecommerce.users.warmup.annotations.WarmupFunction
 import it.pagopa.ecommerce.users.warmup.utils.WarmupUtils
 import it.pagopa.generated.ecommerce.users.api.UserApi
 import it.pagopa.generated.ecommerce.users.model.UserLastPaymentMethodData
-import java.time.Duration
-import java.util.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -14,6 +12,8 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.*
 
 @RestController("LastUsageControllerV1")
 class LastUsageController(
@@ -68,6 +68,6 @@ class LastUsageController(
                     .retrieve()
                     .toBodilessEntity()
             }
-            .block(Duration.ofSeconds(10))
+            .block(Duration.ofSeconds(30))
     }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/controllers/v1/LastUsageController.kt
@@ -1,19 +1,25 @@
 package it.pagopa.ecommerce.users.controllers.v1
 
 import it.pagopa.ecommerce.users.services.UserStatisticsService
+import it.pagopa.ecommerce.users.warmup.annotations.WarmupFunction
+import it.pagopa.ecommerce.users.warmup.utils.WarmupUtils
 import it.pagopa.generated.ecommerce.users.api.UserApi
 import it.pagopa.generated.ecommerce.users.model.UserLastPaymentMethodData
+import java.time.Duration
 import java.util.*
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 
 @RestController("LastUsageControllerV1")
-class LastUsageController(@Autowired private val userStatisticsService: UserStatisticsService) :
-    UserApi {
+class LastUsageController(
+    @Autowired private val userStatisticsService: UserStatisticsService,
+    private val webClient: WebClient = WebClient.create(),
+) : UserApi {
 
     override fun getLastPaymentMethodUsed(
         xUserId: UUID,
@@ -43,4 +49,25 @@ class LastUsageController(@Autowired private val userStatisticsService: UserStat
                 .saveUserLastUsedMethodInfo(userId = xUserId, userLastPaymentMethodData = it)
                 .map { ResponseEntity.status(HttpStatus.CREATED).build() }
         }
+
+    @WarmupFunction
+    fun saveAndGetUserLastPaymentMethodUsedWarmupFunction() {
+        webClient
+            .post()
+            .uri(WarmupUtils.LAST_PAYMENT_METHOD_USED_PATH)
+            .bodyValue(WarmupUtils.warmupLastMethodUsedBody)
+            .header(WarmupUtils.X_USER_ID_HEADER_KEY, WarmupUtils.zeroUUID.toString())
+            .retrieve()
+            .toBodilessEntity()
+            .flatMap {
+                // perform GET right after performing warmup POST request
+                webClient
+                    .get()
+                    .uri(WarmupUtils.LAST_PAYMENT_METHOD_USED_PATH)
+                    .header(WarmupUtils.X_USER_ID_HEADER_KEY, WarmupUtils.zeroUUID.toString())
+                    .retrieve()
+                    .toBodilessEntity()
+            }
+            .block(Duration.ofSeconds(10))
+    }
 }

--- a/src/main/kotlin/it/pagopa/ecommerce/users/warmup/ControllersWarmup.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/warmup/ControllersWarmup.kt
@@ -1,0 +1,71 @@
+package it.pagopa.ecommerce.users.warmup
+
+import it.pagopa.ecommerce.users.warmup.annotations.WarmupFunction
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.full.hasAnnotation
+import kotlin.system.measureTimeMillis
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.getBeansWithAnnotation
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.stereotype.Component
+import org.springframework.util.ClassUtils
+import org.springframework.web.bind.annotation.RestController
+
+@Component
+class ControllersWarmup : ApplicationListener<ContextRefreshedEvent> {
+
+    private val logger = LoggerFactory.getLogger(this.javaClass)
+    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        val restControllers =
+            event.applicationContext.getBeansWithAnnotation<RestController>().map { it.value }
+        logger.info("Found controllers: [{}]", restControllers.size)
+        restControllers.forEach(this::warmUpController)
+    }
+
+    private fun warmUpController(controllerToWarmUpInstance: Any) {
+        val controllerToWarmUpKClass = ClassUtils.getUserClass(controllerToWarmUpInstance).kotlin
+        var warmUpMethods: Int
+        val elapsedTime = measureTimeMillis {
+            warmUpMethods =
+                runCatching {
+                        controllerToWarmUpKClass.declaredMemberFunctions
+                            .filter { it.hasAnnotation<WarmupFunction>() }
+                            .parallelStream()
+                            .mapToInt {
+                                val result: Result<*>
+                                val intertime = measureTimeMillis {
+                                    result = runCatching {
+                                        logger.info("Invoking function: [{}]", it.toString())
+                                        it.call(controllerToWarmUpInstance)
+                                    }
+                                }
+                                logger.info(
+                                    "Warmup function: [{}] -> elapsed time: [{}]. Is ok: [{}] ",
+                                    it.toString(),
+                                    intertime,
+                                    result.isSuccess
+                                )
+                                if (result.isFailure) {
+                                    logger.error(
+                                        "Error performing warmup method: [$it]",
+                                        result.exceptionOrNull()
+                                    )
+                                }
+                                1
+                            }
+                            .sum()
+                    }
+                    .getOrElse {
+                        logger.error("Exception performing controller warm up ", it)
+                        0
+                    }
+        }
+        logger.info(
+            "Controller: [{}] warm-up executed functions: [{}], elapsed time: [{}] ms",
+            controllerToWarmUpKClass,
+            warmUpMethods,
+            elapsedTime
+        )
+    }
+}

--- a/src/main/kotlin/it/pagopa/ecommerce/users/warmup/annotations/WarmupFunction.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/warmup/annotations/WarmupFunction.kt
@@ -1,0 +1,10 @@
+package it.pagopa.ecommerce.users.warmup.annotations
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+/**
+ * Annotation used to annotate a controller function to be called during module warm-up phase.
+ * Warm-up function can be used to send request to a RestController in order to initialize all it's
+ * resource before the module being ready to serve requests
+ */
+annotation class WarmupFunction {}

--- a/src/main/kotlin/it/pagopa/ecommerce/users/warmup/exceptions/WarmUpException.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/warmup/exceptions/WarmUpException.kt
@@ -1,0 +1,4 @@
+package it.pagopa.ecommerce.users.warmup.exceptions
+
+class WarmUpException(controllerName: String, functionName: String) :
+    RuntimeException("Exception performing warm-up function $controllerName.$functionName") {}

--- a/src/main/kotlin/it/pagopa/ecommerce/users/warmup/utils/WarmupUtils.kt
+++ b/src/main/kotlin/it/pagopa/ecommerce/users/warmup/utils/WarmupUtils.kt
@@ -1,0 +1,16 @@
+package it.pagopa.ecommerce.users.warmup.utils
+
+import it.pagopa.generated.ecommerce.users.model.WalletLastUsageData
+import java.time.OffsetDateTime
+import java.util.*
+
+object WarmupUtils {
+    const val LAST_PAYMENT_METHOD_USED_PATH = "http://localhost:8080/user/lastPaymentMethodUsed"
+    const val X_USER_ID_HEADER_KEY = "x-user-id"
+    val zeroUUID: UUID = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    val warmupLastMethodUsedBody =
+        WalletLastUsageData().apply {
+            this.walletId = zeroUUID
+            this.date = OffsetDateTime.now()
+        }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
Add logic to perform controller warmup:
warmup function will execute POST and GET api call to warmup controllers.
For userId have been used a special `null` UUID that is an UUID set to 0
<!--- Describe your changes in detail -->

#### Motivation and Context
Those modifications are needed in order to perform Controller warmups before making service ready
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
Local tests + test in DEV env (service deploy checking warmup requests are performed at service startup)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):
```code
{"@timestamp":"2024-10-07T13:41:32.141Z","log.level": "INFO","message":"Found controllers: [1]","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"main","log.logger":"it.pagopa.ecommerce.users.warmup.ControllersWarmup"}
{"@timestamp":"2024-10-07T13:41:34.055Z","log.level": "INFO","message":"Invoking function: [fun it.pagopa.ecommerce.users.controllers.v1.LastUsageController.saveAndGetUserLastPaymentMethodUsedWarmupFunction(): kotlin.Unit]","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"main","log.logger":"it.pagopa.ecommerce.users.warmup.ControllersWarmup"}
{"@timestamp":"2024-10-07T13:41:43.843Z","log.level": "INFO","message":"Saving last used method for userId: [00000000-0000-0000-0000-000000000000]. Last method used data: [class WalletLastUsageData {\n    walletId: 00000000-0000-0000-0000-000000000000\n    date: 2024-10-07T13:41:34.940471541Z\n    type: wallet\n}]","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"reactor-http-epoll-4","log.logger":"it.pagopa.ecommerce.users.services.UserStatisticsService","trace_id":"16af23acb23c2d4dbef58f800260c9b3","trace_flags":"01","span_id":"9197087a6f383777"}
{"@timestamp":"2024-10-07T13:41:49.247Z","log.level": "INFO","message":"Finding last method used for userId: [00000000-0000-0000-0000-000000000000]","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"reactor-http-epoll-3","log.logger":"it.pagopa.ecommerce.users.services.UserStatisticsService","trace_id":"98e2192e8d0896b080e2c354ee49fbe4","trace_flags":"01","span_id":"004f2f2aff3578e7"}
{"@timestamp":"2024-10-07T13:41:50.358Z","log.level": "INFO","message":"Last used data found for userId: [00000000-0000-0000-0000-000000000000] -> class WalletLastUsageData {\n    walletId: 00000000-0000-0000-0000-000000000000\n    date: 2024-10-07T13:41:34.940471541Z\n    type: null\n}","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"nioEventLoopGroup-3-2","log.logger":"it.pagopa.ecommerce.users.services.UserStatisticsService","trace_id":"98e2192e8d0896b080e2c354ee49fbe4","trace_flags":"01","span_id":"004f2f2aff3578e7"}
{"@timestamp":"2024-10-07T13:41:50.446Z","log.level": "INFO","message":"Warmup function: [fun it.pagopa.ecommerce.users.controllers.v1.LastUsageController.saveAndGetUserLastPaymentMethodUsedWarmupFunction(): kotlin.Unit] -> elapsed time: [16396]. Is ok: [true] ","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"main","log.logger":"it.pagopa.ecommerce.users.warmup.ControllersWarmup"}
{"@timestamp":"2024-10-07T13:41:50.446Z","log.level": "INFO","message":"Controller: [class it.pagopa.ecommerce.users.controllers.v1.LastUsageController] warm-up executed functions: [1], elapsed time: [18304] ms","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"main","log.logger":"it.pagopa.ecommerce.users.warmup.ControllersWarmup"}
{"@timestamp":"2024-10-07T13:41:50.450Z","log.level": "INFO","message":"Started UserApplicationKt in 97.708 seconds (process running for 130.488)","ecs.version": "1.2.0","service.name":"undefined","service.version":"0.1.2","service.environment":"undefined","event.dataset":"undefined","process.thread.name":"main","log.logger":"it.pagopa.ecommerce.users.UserApplicationKt"}

```
#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
