### PR TITLE
feat: [CHK-3781] upgrade to helm chart 7

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: microservice-chart
   repository: https://pagopa.github.io/aks-microservice-chart-blueprint
-  version: 2.8.0
-digest: sha256:379d9a7c312874dd1771386d92d8f597cb3fed497bb80dfde102513b582123d4
-generated: "2023-11-09T10:45:20.978616+01:00"
+  version: 7.4.0
+digest: sha256:ba6c74f4d1b23251f9256f33bbc5ac6eaaf586569c0b43e37ad413f6d36ceabe
+generated: "2025-03-06T16:41:44.372938+01:00"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -6,5 +6,5 @@ version: 1.0.2
 appVersion: 1.0.2
 dependencies:
   - name: microservice-chart
-    version: 2.8.0
+    version: 7.4.0
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -5,18 +5,17 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopadcommonacr.azurecr.io/pagopaecommerceuserstatsservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig: {}
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopadcommonacr.azurecr.io/pagopaecommerceuserstatsservice
+      tag: "latest"
+    envConfig: {}
+    envSecret: {}
   image:
     repository: pagopadcommonacr.azurecr.io/pagopaecommerceuserstatsservice
     tag: "1.0.2"
@@ -52,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -124,3 +123,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 1be61b58-24e2-49c8-b401-89ebd004bf2e

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -5,18 +5,17 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopapcommonacr.azurecr.io/pagopaecommerceuserstatsservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig: {}
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopapcommonacr.azurecr.io/pagopaecommerceuserstatsservice
+      tag: "latest"
+    envConfig: {}
+    envSecret: {}
   image:
     repository: pagopapcommonacr.azurecr.io/pagopaecommerceuserstatsservice
     tag: "1.0.2"
@@ -52,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -138,3 +137,5 @@ microservice-chart:
                 app.kubernetes.io/instance: pagopaecommerceuserstatsservice
             namespaces: ["ecommerce"]
             topologyKey: topology.kubernetes.io/zone
+  azure:
+    workloadIdentityClientId: "d5614882-90dd-47a1-aad1-cdf295201469"

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -5,18 +5,17 @@ microservice-chart:
   canaryDelivery:
     create: false
     ingress:
-      create: true
-      canary:
-        type: bluegreen
-    service:
-      create: true
-    deployment:
-      create: true
-      image:
-        repository: pagopaucommonacr.azurecr.io/pagopaecommerceuserstatsservice
-        tag: "latest"
-        pullPolicy: Always
-      envConfig: {}
+      bluegreen: false
+      #set canary deployment with traffic balancing see https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#canary for more info
+      header: true
+      headerName: deployment
+      headerValue: blue
+      weightPercent: 10
+    image:
+      repository: pagopaucommonacr.azurecr.io/pagopaecommerceuserstatsservice
+      tag: "latest"
+    envConfig: {}
+    envSecret: {}
   image:
     repository: pagopaucommonacr.azurecr.io/pagopaecommerceuserstatsservice
     tag: "1.0.2"
@@ -52,8 +51,8 @@ microservice-chart:
     servicePort: 8080
   serviceAccount:
     create: false
-    annotations: {}
-    name: ""
+    annotations: { }
+    name: "ecommerce-workload-identity"
   podAnnotations: {}
   podSecurityContext:
     seccompProfile:
@@ -125,3 +124,5 @@ microservice-chart:
                 operator: In
                 values:
                   - user
+  azure:
+    workloadIdentityClientId: 449c5b65-f368-487a-881a-b03676420c53


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

Upgrade to helm chart 7 from helm chart 2.

#### List of Changes
Upgrade to helm chart 7 performing the following modifications:
- chat version update from 2.8 to 7.4.0
- canaryDelivery parameter update to the new template (adding canary section)
- add workload identity refs for each environment specifying the azure workload identity client id and service account name for each env

#### Motivation and Context
These modifications are needed to enable the eCommerce user stats service to use workload identities instead of the deprecated pod identity.
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

No tests yet

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.